### PR TITLE
Upgrade to go 1.23.

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,8 +13,7 @@ jobs:
   golangci:
     strategy:
       matrix:
-        # Currently having linter issues with 1.23.0.
-        go: ['1.19', '1.22.6']
+        go: ['1.23']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,4 +22,4 @@ jobs:
           go-version: ${{ matrix.go }}
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.59.1
+          version: v1.61.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,9 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        # Currently having linter issues with 1.23.0,
-        # so it's safest to limit this version as well.
-        go: ['1.19', '1.22.6']
+        go: ['1.23']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -88,6 +88,7 @@ linters:
     # causes problems if golangci-lint is compiled with a different version of go
     - typecheck
     # not needed/wanted in this project
+    - exportloopref     # not needed with Go 1.22+
     - execinquery       # SQL not used
     - ginkgolinter      # not using this testing framework
     - gochecknoglobals  # no config options to limit to exported elements

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/phiryll/btrie
 
-go 1.19
+go 1.23
 
 require github.com/stretchr/testify v1.9.0
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -79,7 +79,7 @@ func testBTrie(t *testing.T, f func() BTrie, seed int64) {
 	random := rand.New(rand.NewSource(seed))
 	ref := newReference()
 
-	for i := 0; i < opCount; i++ {
+	for range opCount {
 		entry := Entry{randomKey(random), randomBytes(1, random)}
 		switch randOp := random.Float32(); {
 		case randOp < 0.5:
@@ -98,7 +98,7 @@ func testBTrie(t *testing.T, f func() BTrie, seed int64) {
 	}
 	assert.Equal(t, collect(ref.Range(nil, nil)), collect(bt.Range(nil, nil)))
 
-	for i := 0; i < rangeCount; i++ {
+	for range rangeCount {
 		begin := randomKey(random)
 		end := randomKey(random)
 		if bytes.Equal(begin, end) {


### PR DESCRIPTION
The reason is to use the iter package.
