### PR TITLE
refactor interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,3 @@ Binary tries make an excellent in-memory index for [lexicographically
 byte-ordered data](https://github.com/phiryll/lexy). The principles
 could also possibly be applied to a [data history tracking
 database](https://phiryll.github.io/projects/data-history.html).
-
-## TODO
-
-After the initial implementations, define a common interface. Use this
-to allow different representations at different locations in the trie.
-The goal would be to locally self-optimize the trie for speed or
-space. I'm specifically considering sparse vs. dense data, but there
-may be other possibilities. This is probably not feasible for the
-fully or partially persistent variants since those need to maintain
-all history.

--- a/btrie.go
+++ b/btrie.go
@@ -3,10 +3,10 @@ package btrie
 
 // BTrie is ....
 type BTrie interface {
-	Put(key, value []byte) (previous []byte)
-	Get(key []byte) []byte
-	Delete(key []byte) (previous []byte)
-	Range(begin, end []byte) Cursor
+	DeprPut(key, value []byte) (previous []byte)
+	DeprGet(key []byte) []byte
+	DeprDelete(key []byte) (previous []byte)
+	DeprRange(begin, end []byte) Cursor
 }
 
 // Cursor is the type returned by [BTrie.Range].

--- a/btrie.go
+++ b/btrie.go
@@ -1,51 +1,12 @@
 // Package btrie defines interfaces for and provides multiple implementations of a binary trie.
 package btrie
 
-// nil keys and values are not allowed, which allows nil to mean "does not exist".
-// empty keys are not allowed, must be at least one byte, at least for now.
-
-// see if it's worthwhile to upgrade to go 1.23 to use the iter package
-// probably a good idea to at least follow the structure and naming conventions
-
-// How do you get a handle to a specific version?
-// This isn't necessary for the neither persistent nor thread-safe variant.
-// This argues for some other interface.
-
-// Is each Put a new version, or is there some concept of transaction?
-
-// Implement, in order???
-// - neither persistent nor thread-safe
-//   as simple as possible, linked nodes first, then tables
-//   this is first to get most of the API right
-// - thread-safe
-//   does not allow reading previous versions,
-//   but does allow continuing to read a version that you have the handle of
-//   so the operations aren't thread-safe, but the entire snapshot is
-// - fully persistent and thread-safe
-//   every version can accessed and be modified
-//   this is only useful in my personal use cases if there's a merge operation,
-//   which would make this confluently persistent
-// - partially persistent and thread-safe
-//   all versions can be accessed but only newest can be modified
-
 // BTrie is ....
 type BTrie interface {
-	// Potential methods, still fleshing this out.
-
 	Put(key, value []byte) (previous []byte)
 	Get(key []byte) []byte
 	Delete(key []byte) (previous []byte)
-	// Get(key []byte, value *[]byte)  // to avoid allocations
-
-	// if begin > end, go backwards.
-	// alternatively:
-	//   Cursor() Cursor
-	//     First/Last/Seek, Set/Delete, Next/Prev (key, value []byte)
 	Range(begin, end []byte) Cursor
-
-	// nil value => put-if-absent
-	// not necessary with transactions
-	// PutIf(key, value []byte) (found bool)
 }
 
 // Cursor is the type returned by [BTrie.Range].
@@ -53,15 +14,3 @@ type Cursor interface {
 	HasNext() bool
 	Next() (key, value []byte)
 }
-
-// NewSimple returns a new, absurdly simple, and badly coded BTrie.
-// This is purely for fleshing out the unit tests, benchmarks, and fuzz tests.
-func NewSimple() BTrie {
-	return &node{nil, nil, 0}
-}
-
-// EmptySeq is an empty [iter.Seq].
-func EmptySeq[T any](_ func(T) bool) {}
-
-// EmptySeq2 is an empty [iter.Seq2].
-func EmptySeq2[K, V any](_ func(K, V) bool) {}

--- a/btrie.go
+++ b/btrie.go
@@ -1,20 +1,6 @@
 // Package btrie defines interfaces for and provides multiple implementations of a binary trie.
 package btrie
 
-// BTrie is ....
-type BTrie[V any] interface {
-	DeprPut(key []byte, value V) (previous V)
-	DeprGet(key []byte) V
-	DeprDelete(key []byte) (previous V)
-	DeprRange(begin, end []byte) Cursor[V]
-}
-
-// Cursor is the type returned by [BTrie.Range].
-type Cursor[V any] interface {
-	HasNext() bool
-	Next() (key []byte, value V)
-}
-
 type Entry[V any] struct {
 	Key   []byte
 	Value V

--- a/btrie.go
+++ b/btrie.go
@@ -1,7 +1,2 @@
 // Package btrie defines interfaces for and provides multiple implementations of a binary trie.
 package btrie
-
-type Entry[V any] struct {
-	Key   []byte
-	Value V
-}

--- a/btrie.go
+++ b/btrie.go
@@ -2,15 +2,20 @@
 package btrie
 
 // BTrie is ....
-type BTrie interface {
-	DeprPut(key, value []byte) (previous []byte)
-	DeprGet(key []byte) []byte
-	DeprDelete(key []byte) (previous []byte)
-	DeprRange(begin, end []byte) Cursor
+type BTrie[V any] interface {
+	DeprPut(key []byte, value V) (previous V)
+	DeprGet(key []byte) V
+	DeprDelete(key []byte) (previous V)
+	DeprRange(begin, end []byte) Cursor[V]
 }
 
 // Cursor is the type returned by [BTrie.Range].
-type Cursor interface {
+type Cursor[V any] interface {
 	HasNext() bool
-	Next() (key, value []byte)
+	Next() (key []byte, value V)
+}
+
+type Entry[V any] struct {
+	Key   []byte
+	Value V
 }

--- a/btrie_test.go
+++ b/btrie_test.go
@@ -8,5 +8,5 @@ import (
 
 func TestSimple(t *testing.T) {
 	t.Parallel()
-	testBTrie(t, btrie.DeprNewSimple[byte], 290709)
+	testBTrie(t, btrie.NewSimple[byte], 290709)
 }

--- a/btrie_test.go
+++ b/btrie_test.go
@@ -8,5 +8,5 @@ import (
 
 func TestSimple(t *testing.T) {
 	t.Parallel()
-	testBTrie(t, btrie.DeprNewSimple[[]byte], 290709)
+	testBTrie(t, btrie.DeprNewSimple[byte], 290709)
 }

--- a/btrie_test.go
+++ b/btrie_test.go
@@ -8,5 +8,5 @@ import (
 
 func TestSimple(t *testing.T) {
 	t.Parallel()
-	testBTrie(t, btrie.NewSimple, 290709)
+	testBTrie(t, btrie.DeprNewSimple[[]byte], 290709)
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -15,6 +15,11 @@ import (
 
 type (
 	Bounds = btrie.Bounds
+
+	entry[V any] struct {
+		Key   []byte
+		Value V
+	}
 )
 
 var (
@@ -23,10 +28,10 @@ var (
 	all = From(nil).To(nil)
 )
 
-func collect[V any](itr iter.Seq2[[]byte, V]) []btrie.Entry[V] {
-	entries := []btrie.Entry[V]{}
+func collect[V any](itr iter.Seq2[[]byte, V]) []entry[V] {
+	entries := []entry[V]{}
 	for k, v := range itr {
-		entries = append(entries, btrie.Entry[V]{k, v})
+		entries = append(entries, entry[V]{k, v})
 	}
 	return entries
 }
@@ -42,10 +47,10 @@ func testShortKey(t *testing.T, f func() btrie.OrderedBytesMap[byte]) {
 	// bt.Put([]byte{5}, 0)
 	bt.Put([]byte{5}, 0)
 	assert.Equal(t,
-		[]btrie.Entry[byte]{},
+		[]entry[byte]{},
 		collect(bt.Range(From([]byte{5, 0}).To([]byte{6}))))
 	assert.Equal(t,
-		[]btrie.Entry[byte]{{[]byte{5}, 0}},
+		[]entry[byte]{{[]byte{5}, 0}},
 		collect(bt.Range(From([]byte{4}).To([]byte{5, 0}))))
 }
 
@@ -85,7 +90,7 @@ func testBTrie(t *testing.T, f func() btrie.OrderedBytesMap[byte], seed int64) {
 	ref := newReference()
 
 	for range opCount {
-		entry := btrie.Entry[byte]{randomKey(random), randomByte(random)}
+		entry := entry[byte]{randomKey(random), randomByte(random)}
 		switch randOp := random.Float32(); {
 		case randOp < 2.0:
 			expected, expectedOk := ref.Put(entry.Key, entry.Value)

--- a/orderedbytesmap.go
+++ b/orderedbytesmap.go
@@ -92,22 +92,12 @@ func (b *Bounds) DownTo(key []byte) *Bounds {
 func (b *Bounds) Contains(key []byte) bool {
 	if b.Reverse {
 		// end < key <= begin
-		if b.End != nil && bytes.Compare(key, b.End) <= 0 {
-			return false
-		}
-		if b.Begin != nil && bytes.Compare(key, b.Begin) > 0 {
-			return false
-		}
-	} else {
-		// begin <= key < end
-		if b.Begin != nil && bytes.Compare(key, b.Begin) < 0 {
-			return false
-		}
-		if b.End != nil && bytes.Compare(key, b.End) >= 0 {
-			return false
-		}
+		return (b.End == nil || bytes.Compare(b.End, key) < 0) &&
+			(b.Begin == nil || bytes.Compare(key, b.Begin) <= 0)
 	}
-	return true
+	// begin <= key < end
+	return (b.Begin == nil || bytes.Compare(b.Begin, key) <= 0) &&
+		(b.End == nil || bytes.Compare(key, b.End) < 0)
 }
 
 // A Pos represents a mutable position in the sequence returned by [OrderedBytesMap.Cursor].

--- a/orderedbytesmap.go
+++ b/orderedbytesmap.go
@@ -1,0 +1,180 @@
+package btrie
+
+import (
+	"bytes"
+	"fmt"
+	"iter"
+)
+
+// OrderedBytesMap is essentially an ordered map[[]byte]V.
+// Keys must be non-nil.
+// A nil key returned by any method generally means "does not exist".
+// Implementations must clearly document any additional constraints on keys and values.
+// Implementations must clearly document if any methods accept or return references to its internal storage.
+// All OrderedBytesMap implementations in this package are tries.
+type OrderedBytesMap[V any] interface {
+	// Put sets the value for key, returning the previous value.
+	// Put will panic if this OrderedBytesMap does not support mutation.
+	Put(key []byte, value V) (previous V, ok bool)
+
+	// Get returns the value for key.
+	Get(key []byte) (value V, ok bool)
+
+	// Delete removes the value for key, returning the previous value.
+	// Delete will panic if this OrderedBytesMap does not support mutation.
+	Delete(key []byte) (previous V, ok bool)
+
+	// Range does stuff.
+	// Implementations should consider making a defensive copy of bounds using [Bounds.Clone].
+	Range(bounds *Bounds) iter.Seq2[[]byte, V]
+
+	// Cursor does stuff.
+	// Implementations should consider making a defensive copy of bounds using [Bounds.Clone].
+	// Cursor will panic if this OrderedBytesMap does not support mutation.
+	Cursor(bounds *Bounds) iter.Seq[Pos[V]]
+}
+
+// Bounds is the argument type for [OrderedBytesMap.Range] and [OrderedBytesMap.Cursor].
+// A nil value for [Bounds.Begin] or [Bounds.End] represents +/-Inf;
+// which one depends on the value of [Bounds.Reverse].
+// Note that an empty bounds value is not nil; -Inf < []byte{} < []byte{0}.
+// For non-nil values, Begin is inclusive and End is exclusive regardless of the direction.
+// While a Bounds instance can be constructed directly, using [From] with [Bounds.To] or [Bounds.DownTo] is clearer.
+type Bounds struct {
+	Begin, End []byte
+	Reverse    bool
+}
+
+// From creates a new Bounds with bounds.Begin=key.
+func From(key []byte) *Bounds {
+	return &Bounds{key, nil, false}
+}
+
+// Clone returns a deep copy of b.
+func (b *Bounds) Clone() *Bounds {
+	return &Bounds{
+		bytes.Clone(b.Begin),
+		bytes.Clone(b.End),
+		b.Reverse,
+	}
+}
+
+func (b *Bounds) String() string {
+	if b.Reverse {
+		return fmt.Sprintf("[%X down to %X]", b.Begin, b.End)
+	}
+	return fmt.Sprintf("[%X to %X]", b.Begin, b.End)
+}
+
+// To sets b.End to key and b.Reverse to false, returning b.
+// To will panic if b.Begin >= b.End.
+func (b *Bounds) To(key []byte) *Bounds {
+	if b.Begin != nil && key != nil && bytes.Compare(b.Begin, key) >= 0 {
+		panic("bounds From >= To")
+	}
+	b.End = key
+	b.Reverse = false
+	return b
+}
+
+// DownTo sets b.End to key and b.Reverse to true, returning b.
+// DownTo will panic if b.Begin <= b.End.
+func (b *Bounds) DownTo(key []byte) *Bounds {
+	if b.Begin != nil && key != nil && bytes.Compare(b.Begin, key) <= 0 {
+		panic("bounds From <= DownTo")
+	}
+	b.End = key
+	b.Reverse = true
+	return b
+}
+
+// Contains returns whether key is within b.
+func (b *Bounds) Contains(key []byte) bool {
+	if b.Reverse {
+		// end < key <= begin
+		if b.End != nil && bytes.Compare(key, b.End) <= 0 {
+			return false
+		}
+		if b.Begin != nil && bytes.Compare(key, b.Begin) > 0 {
+			return false
+		}
+	} else {
+		// begin <= key < end
+		if b.Begin != nil && bytes.Compare(key, b.Begin) < 0 {
+			return false
+		}
+		if b.End != nil && bytes.Compare(key, b.End) >= 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// A Pos represents a mutable position in the sequence returned by [OrderedBytesMap.Cursor].
+type Pos[V any] interface {
+	// Key returns the key at this position.
+	Key() []byte
+
+	// Value returns the value at this position.
+	Value() V
+
+	// Set sets the value at this position.
+	Set(value V)
+
+	// Delete removes the key/value pair at this position.
+	Delete()
+}
+
+// DefaultPos is a default Pos implementation which delegates to the containing OrderedBytesMap.
+// Do not use this implementation if Set or Delete might corrupt the Cursor which created it.
+func DefaultPos[V any](bMap OrderedBytesMap[V], key []byte) Pos[V] {
+	return &position[V]{bMap, key}
+}
+
+type position[V any] struct {
+	bMap OrderedBytesMap[V]
+	key  []byte
+}
+
+func (p *position[V]) Key() []byte {
+	return p.key
+}
+
+func (p *position[V]) Value() V {
+	value, _ := p.bMap.Get(p.key)
+	return value
+}
+
+func (p *position[V]) Set(value V) {
+	p.bMap.Put(p.key, value)
+}
+
+func (p *position[V]) Delete() {
+	p.bMap.Delete(p.key)
+}
+
+// EmptySeq is an empty [iter.Seq].
+func EmptySeq[T any](_ func(T) bool) {}
+
+// EmptySeq2 is an empty [iter.Seq2].
+func EmptySeq2[K, V any](_ func(K, V) bool) {}
+
+// TODO: After the initial implementations, define a common interface (maybe the same?).
+// Use this to allow different representations at different locations in the trie.
+// The goal would be to locally self-optimize the trie for speed or space.
+// I'm specifically considering sparse vs. dense data, but there may be other possibilities.
+// This is probably not feasible for the fully or partially persistent variants
+// since those need to maintain all history.
+
+// Note: iteraters need to clean up before returning
+// BIG Note: Document iter.Seq/Seq2 if single use. Multiple use would look like:
+//   it := bMap.Range(From(begin).To(end))
+//   for k, v := range it {
+//     do stuff
+//   }
+//   for k, v := range it {
+//     do more stuff
+//   }
+
+// The reference collecting versions need to use runtime.SetFinalizer(). See
+// https://stackoverflow.com/questions/63025066/is-it-safe-to-use-a-uintptr-as-a-weak-reference

--- a/reference_test.go
+++ b/reference_test.go
@@ -10,10 +10,6 @@ import (
 	"github.com/phiryll/btrie"
 )
 
-func deprNewReference() btrie.BTrie[byte] {
-	return &reference{map[int32]byte{}}
-}
-
 func newReference() btrie.OrderedBytesMap[byte] {
 	return &reference{map[int32]byte{}}
 }

--- a/reference_test.go
+++ b/reference_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"iter"
 	"slices"
-	"sort"
 
 	"github.com/phiryll/btrie"
 )
@@ -103,61 +102,4 @@ func (r *reference) Cursor(bounds *Bounds) iter.Seq[btrie.Pos[byte]] {
 			}
 		}
 	}
-}
-
-func (r *reference) DeprPut(key []byte, value byte) byte {
-	prev, ok := r.Put(key, value)
-	if !ok {
-		return 0
-	}
-	return prev
-}
-
-func (r *reference) DeprGet(key []byte) byte {
-	value, ok := r.Get(key)
-	if !ok {
-		return 0
-	}
-	return value
-}
-
-func (r *reference) DeprDelete(key []byte) byte {
-	value, ok := r.Delete(key)
-	if !ok {
-		return 0
-	}
-	return value
-}
-
-func (r *reference) DeprRange(begin, end []byte) btrie.Cursor[byte] {
-	entries := []btrie.Entry[byte]{}
-	for k, v := range r.m {
-		key := refKey(k)
-		if begin != nil && bytes.Compare(key, begin) < 0 {
-			continue
-		}
-		if end != nil && bytes.Compare(key, end) >= 0 {
-			continue
-		}
-		entries = append(entries, btrie.Entry[byte]{key, v})
-	}
-	sort.Slice(entries, func(i, j int) bool {
-		return bytes.Compare(entries[i].Key, entries[j].Key) < 0
-	})
-	return &deprCursor[byte]{entries, 0}
-}
-
-type deprCursor[V any] struct {
-	entries []btrie.Entry[V]
-	index   int
-}
-
-func (c *deprCursor[V]) HasNext() bool {
-	return c.index < len(c.entries)
-}
-
-func (c *deprCursor[V]) Next() ([]byte, V) {
-	entry := c.entries[c.index]
-	c.index++
-	return entry.Key, entry.Value
 }

--- a/simple.go
+++ b/simple.go
@@ -16,13 +16,6 @@ import (
 // no way to distinguish the root from an internal node,
 // so top-level functions must handle it differently.
 
-// DeprNewSimple returns a new, absurdly simple, and badly coded BTrie.
-// This is purely for fleshing out the unit tests, benchmarks, and fuzz tests.
-func DeprNewSimple[V any]() BTrie[V] {
-	var zero V
-	return &node[V]{zero, nil, 0, false}
-}
-
 // NewSimple returns a new, absurdly simple, and badly coded OrderedBytesMap.
 // This is purely for fleshing out the unit tests, benchmarks, and fuzz tests.
 func NewSimple[V any]() OrderedBytesMap[V] {

--- a/simple.go
+++ b/simple.go
@@ -15,6 +15,12 @@ import (
 // no way to distinguish the root from an internal node,
 // so top-level functions must handle it differently.
 
+// NewSimple returns a new, absurdly simple, and badly coded BTrie.
+// This is purely for fleshing out the unit tests, benchmarks, and fuzz tests.
+func NewSimple() BTrie {
+	return &node{nil, nil, 0}
+}
+
 type node struct {
 	children []*node
 	value    []byte // non-nil only if this is a terminal node

--- a/simple.go
+++ b/simple.go
@@ -54,7 +54,7 @@ func (n *node) printNode(s *strings.Builder, indent string) {
 	}
 }
 
-func (n *node) Put(key, value []byte) []byte {
+func (n *node) DeprPut(key, value []byte) []byte {
 	if len(key) == 0 {
 		panic("key must be non-empty")
 	}
@@ -65,7 +65,7 @@ func (n *node) Put(key, value []byte) []byte {
 	return n.put(key, value)
 }
 
-func (n *node) Get(key []byte) []byte {
+func (n *node) DeprGet(key []byte) []byte {
 	// TODO: this does not need to recurse
 	index, found := n.search(key[0])
 	if !found {
@@ -74,16 +74,16 @@ func (n *node) Get(key []byte) []byte {
 	if len(key) == 1 {
 		return n.children[index].value
 	}
-	return n.children[index].Get(key[1:])
+	return n.children[index].DeprGet(key[1:])
 }
 
-func (n *node) Delete(key []byte) []byte {
+func (n *node) DeprDelete(key []byte) []byte {
 	// TODO: this does not need to recurse
 	_, value := n.deleteKey(key)
 	return value
 }
 
-func (n *node) Range(begin, end []byte) Cursor {
+func (n *node) DeprRange(begin, end []byte) Cursor {
 	var entries []entry
 	// TODO: make this lazy and non-recursive - DFS
 


### PR DESCRIPTION
- **Add OrderedBytesMap interface to replace BTrie.**
- **Have reference implement OrderedBinaryMap[byte].**
- **Deprecate elements of the simple BTrie implementation.**
- **Make the simple BTrie implementation generic.**
- **Have simple BTrie implement OrderedBytesMap[V].**
- **Migrate tests from BTrie to OrderedBytesMap.**
- **Remove deprecated elements, including BTrie and Cursor.**
- **Unexport entry structs.**
- **Fix linter issues.**
