### PR TITLE
add array trie

### DIFF
--- a/arraytrie.go
+++ b/arraytrie.go
@@ -1,0 +1,249 @@
+package btrie
+
+import (
+	"bytes"
+	"fmt"
+	"iter"
+	"strings"
+)
+
+type arrayTrieNode[V any] struct {
+	value      V // valid only if isTerminal is true
+	children   [256]*arrayTrieNode[V]
+	isTerminal bool
+}
+
+func newArrayTrieNode[V any](value V, isTerminal bool) *arrayTrieNode[V] {
+	return &arrayTrieNode[V]{value, [256]*arrayTrieNode[V]{}, isTerminal}
+}
+
+// NewArrayTrie returns a new BTrie with pointers to children stored in arrays.
+func NewArrayTrie[V any]() BTrie[V] {
+	var zero V
+	return newArrayTrieNode(zero, false)
+}
+
+func (n *arrayTrieNode[V]) Get(key []byte) (V, bool) {
+	if key == nil {
+		panic("key must be non-nil")
+	}
+	var zero V
+	for _, keyByte := range key {
+		n = n.children[keyByte]
+		if n == nil {
+			return zero, false
+		}
+	}
+	// n = found key
+	if n.isTerminal {
+		return n.value, true
+	}
+	return zero, false
+}
+
+func (n *arrayTrieNode[V]) Put(key []byte, value V) (V, bool) {
+	if key == nil {
+		panic("key must be non-nil")
+	}
+	var zero V
+	for i, keyByte := range key {
+		if n.children[keyByte] == nil {
+			k := len(key) - 1
+			child := newArrayTrieNode(value, true)
+			for k--; k >= i; k-- {
+				parent := newArrayTrieNode(zero, false)
+				parent.children[key[k+1]] = child
+				child = parent
+			}
+			n.children[keyByte] = child
+			return zero, false
+		}
+		n = n.children[keyByte]
+	}
+	// n = found key, replace value
+	if n.isTerminal {
+		prev := n.value
+		n.value = value
+		return prev, true
+	}
+	n.value = value
+	n.isTerminal = true
+	return zero, false
+}
+
+func (n *arrayTrieNode[V]) Delete(key []byte) (V, bool) {
+	if key == nil {
+		panic("key must be non-nil")
+	}
+	var zero V
+	// Treating the root key as a special case makes the code below simpler wrt pruning.
+	if len(key) == 0 {
+		if !n.isTerminal {
+			return zero, false
+		}
+		prev := n.value
+		n.value = zero
+		n.isTerminal = false
+		return prev, true
+	}
+
+	// If the deleted node has no children, remove the subtree rooted at prune.children[pruneIndex].
+	prune, pruneIndex := n, byte(0)
+	for _, keyByte := range key {
+		if n.children[keyByte] == nil {
+			return zero, false
+		}
+		// If either n has a value or more than one child, n itself cannot be pruned.
+		// If so, move the maybe-pruned subtree to n.children[index].
+		if n.isTerminal || n.numChildren() > 1 {
+			prune, pruneIndex = n, keyByte
+		}
+		n = n.children[keyByte]
+	}
+	// n = found key
+	if !n.isTerminal {
+		return zero, false
+	}
+	prev := n.value
+	n.value = zero
+	n.isTerminal = false
+	if n.numChildren() == 0 {
+		prune.children[pruneIndex] = nil
+	}
+	return prev, true
+}
+
+func (n *arrayTrieNode[V]) numChildren() int {
+	var count int
+	for _, child := range &n.children {
+		if child != nil {
+			count++
+		}
+	}
+	return count
+}
+
+// An iter.Seq of these is returned from the adjFunction used internally by Range.
+// key = path from root to node
+// It is cached here for efficiency, otherwise an iter.Seq of []*arrayTrieNode[V] would be used directly.
+// Note that the key must be cloned when yielded from Range.
+type arrayTrieRangePath[V any] struct {
+	node *arrayTrieNode[V]
+	key  []byte
+}
+
+func (n *arrayTrieNode[V]) Range(bounds Bounds) iter.Seq2[[]byte, V] {
+	bounds = bounds.Clone()
+	root := arrayTrieRangePath[V]{n, []byte{}}
+	var pathItr iter.Seq[*arrayTrieRangePath[V]]
+	if bounds.IsReverse() {
+		pathItr = postOrder(&root, arrayTrieReverseAdj[V](bounds))
+	} else {
+		pathItr = preOrder(&root, arrayTrieForwardAdj[V](bounds))
+	}
+	return func(yield func([]byte, V) bool) {
+		for path := range pathItr {
+			cmp := bounds.Compare(path.key)
+			if cmp < 0 {
+				continue
+			}
+			if cmp > 0 {
+				return
+			}
+			if path.node == nil {
+				panic("path.node is nil")
+			}
+			if path.key == nil {
+				panic("path.key is nil")
+			}
+			if path.node.isTerminal && !yield(bytes.Clone(path.key), path.node.value) {
+				return
+			}
+		}
+	}
+}
+
+// Sometimes a child is not within the bounds, but one of its descendants is.
+//
+//nolint:gocognit
+func arrayTrieForwardAdj[V any](bounds Bounds) adjFunction[*arrayTrieRangePath[V]] {
+	return func(path *arrayTrieRangePath[V]) iter.Seq[*arrayTrieRangePath[V]] {
+		start, stop, ok := bounds.childBounds(path.key)
+		if !ok {
+			// Unreachable because of how the trie is traversed forward.
+			panic("unreachable")
+		}
+		return func(yield func(*arrayTrieRangePath[V]) bool) {
+			for i, child := range &path.node.children {
+				if child == nil {
+					continue
+				}
+				keyByte := byte(i)
+				if keyByte < start {
+					continue
+				}
+				if keyByte > stop {
+					return
+				}
+				if !yield(&arrayTrieRangePath[V]{child, append(path.key, keyByte)}) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// Sometimes a child is not within the bounds, but one of its descendants is.
+//
+//nolint:gocognit
+func arrayTrieReverseAdj[V any](bounds Bounds) adjFunction[*arrayTrieRangePath[V]] {
+	return func(path *arrayTrieRangePath[V]) iter.Seq[*arrayTrieRangePath[V]] {
+		start, stop, ok := bounds.childBounds(path.key)
+		if !ok {
+			return emptySeq
+		}
+		return func(yield func(*arrayTrieRangePath[V]) bool) {
+			for i := 255; i >= 0; i-- {
+				child := path.node.children[i]
+				if child == nil {
+					continue
+				}
+				keyByte := byte(i)
+				if keyByte > start {
+					continue
+				}
+				if keyByte < stop {
+					return
+				}
+				if !yield(&arrayTrieRangePath[V]{child, append(path.key, keyByte)}) {
+					return
+				}
+			}
+		}
+	}
+}
+
+func (n *arrayTrieNode[V]) String() string {
+	var s strings.Builder
+	n.printNode(&s, 0, "")
+	return s.String()
+}
+
+//nolint:revive
+func (n *arrayTrieNode[V]) printNode(s *strings.Builder, keyByte byte, indent string) {
+	if indent == "" {
+		s.WriteString("[]")
+	} else {
+		fmt.Fprintf(s, "%s%X", indent, keyByte)
+	}
+	if n.isTerminal {
+		fmt.Fprintf(s, ": %v\n", n.value)
+	} else {
+		s.WriteString("\n")
+	}
+	for i, child := range &n.children {
+		if child != nil {
+			child.printNode(s, byte(i), indent+"  ")
+		}
+	}
+}

--- a/arraytrie.go
+++ b/arraytrie.go
@@ -95,7 +95,7 @@ func (n *arrayTrieNode[V]) Delete(key []byte) (V, bool) {
 		}
 		// If either n has a value or more than one child, n itself cannot be pruned.
 		// If so, move the maybe-pruned subtree to n.children[index].
-		if n.isTerminal || n.numChildren() > 1 {
+		if n.isTerminal || n.cardinality() > 1 {
 			prune, pruneIndex = n, keyByte
 		}
 		n = n.children[keyByte]
@@ -107,16 +107,20 @@ func (n *arrayTrieNode[V]) Delete(key []byte) (V, bool) {
 	prev := n.value
 	n.value = zero
 	n.isTerminal = false
-	if n.numChildren() == 0 {
+	if n.cardinality() == 0 {
 		prune.children[pruneIndex] = nil
 	}
 	return prev, true
 }
 
-func (n *arrayTrieNode[V]) numChildren() int {
+// Returns 0, 1, or 2 (for >= 2).
+func (n *arrayTrieNode[V]) cardinality() int {
 	var count int
 	for _, child := range &n.children {
 		if child != nil {
+			if count >= 1 {
+				return 2
+			}
 			count++
 		}
 	}

--- a/btrie.go
+++ b/btrie.go
@@ -13,12 +13,12 @@ import (
 // Implementations must clearly document if the iterator returned by Range is single-use.
 // Although nothing in this interface mandates it, all BTrie implementations in this package are tries.
 type BTrie[V any] interface {
+	// Get returns the value for key and whether or not it exists.
+	Get(key []byte) (value V, ok bool)
+
 	// Put sets the value for key, returning the previous value and whether or not the previous value existed.
 	// Put will panic if this BTrie does not support mutation.
 	Put(key []byte, value V) (previous V, ok bool)
-
-	// Get returns the value for key and whether or not it exists.
-	Get(key []byte) (value V, ok bool)
 
 	// Delete removes the value for key, returning the previous value and whether or not the previous value existed.
 	// Delete will panic if this BTrie does not support mutation.

--- a/btrie.go
+++ b/btrie.go
@@ -31,7 +31,7 @@ type BTrie[V any] interface {
 	Range(bounds Bounds) iter.Seq2[[]byte, V]
 }
 
-func emptySeq[T any](_ func(T) bool) {}
+func emptySeq[V any](_ func(V) bool) {}
 
 func keyName(key []byte) string {
 	if key == nil {

--- a/btrie_test.go
+++ b/btrie_test.go
@@ -153,9 +153,10 @@ var (
 
 func asCloneable(factory func() btrie.BTrie[byte]) func() TestBTrie {
 	return func() TestBTrie {
-		cloneable, ok := factory().(btrie.Cloneable[byte])
+		trie := factory()
+		cloneable, ok := trie.(TestBTrie)
 		if !ok {
-			panic("not Cloneable")
+			panic(fmt.Sprintf("%T is not Cloneable", trie))
 		}
 		return cloneable
 	}

--- a/btrie_test.go
+++ b/btrie_test.go
@@ -78,6 +78,7 @@ var (
 		// fuzz tests assume reference is first
 		{"reference", newReference},
 		{"pointer-trie", asCloneable(btrie.NewPointerTrie[byte])},
+		{"array-trie", asCloneable(btrie.NewArrayTrie[byte])},
 	}
 
 	From       = btrie.From

--- a/export_test.go
+++ b/export_test.go
@@ -38,3 +38,19 @@ func clonePointerTrie[V any](n *ptrTrieNode[V]) *ptrTrieNode[V] {
 	}
 	return &clone
 }
+
+// Assumes V is not a reference type.
+func (n *arrayTrieNode[V]) Clone() Cloneable[V] {
+	return cloneArrayTrie(n)
+}
+
+func cloneArrayTrie[V any](n *arrayTrieNode[V]) *arrayTrieNode[V] {
+	if n == nil {
+		return nil
+	}
+	clone := *n
+	for i, child := range &n.children {
+		clone.children[i] = cloneArrayTrie(child)
+	}
+	return &clone
+}

--- a/export_test.go
+++ b/export_test.go
@@ -26,13 +26,13 @@ type (
 )
 
 // Assumes V is not a reference type.
-func (n *node[V]) Clone() Cloneable[V] {
+func (n *ptrTrieNode[V]) Clone() Cloneable[V] {
 	return clonePointerTrie(n)
 }
 
-func clonePointerTrie[V any](n *node[V]) *node[V] {
+func clonePointerTrie[V any](n *ptrTrieNode[V]) *ptrTrieNode[V] {
 	clone := *n
-	clone.children = make([]*node[V], len(n.children))
+	clone.children = make([]*ptrTrieNode[V], len(n.children))
 	for i, child := range n.children {
 		clone.children[i] = clonePointerTrie(child)
 	}

--- a/export_test.go
+++ b/export_test.go
@@ -49,8 +49,13 @@ func cloneArrayTrie[V any](n *arrayTrieNode[V]) *arrayTrieNode[V] {
 		return nil
 	}
 	clone := *n
-	for i, child := range &n.children {
-		clone.children[i] = cloneArrayTrie(child)
+	if n.children != nil {
+		clone.children = &[256]*arrayTrieNode[V]{}
+		for i, child := range n.children {
+			if child != nil {
+				clone.children[i] = cloneArrayTrie(child)
+			}
+		}
 	}
 	return &clone
 }

--- a/fuzz-all.sh
+++ b/fuzz-all.sh
@@ -9,7 +9,7 @@ cd "$(dirname "$0")"
 rm -f btrie.test
 go test -c
 
-fuzzTime=${1:-10}
+fuzzTime=${1:-30}
 
 files=$(ggrep -r --include='**_test.go' --files-with-matches 'func Fuzz' .)
 

--- a/fuzz.sh
+++ b/fuzz.sh
@@ -16,6 +16,6 @@ rm -f btrie.test
 go test -c
 
 tests=${1:-Get}
-fuzzTime=${2:-10}
+fuzzTime=${2:-30}
 
 go test -fuzz=$tests -fuzztime=${fuzzTime}s

--- a/pointertrie.go
+++ b/pointertrie.go
@@ -149,8 +149,8 @@ func (n *ptrTrieNode[V]) Range(bounds Bounds) iter.Seq2[[]byte, V] {
 	}
 }
 
-// Sometimes a child is not within the bounds, but one of its descendants is.
 func ptrTrieForwardAdj[V any](bounds Bounds) adjFunction[*ptrTrieRangePath[V]] {
+	// Sometimes a child is not within the bounds, but one of its descendants is.
 	return func(path *ptrTrieRangePath[V]) iter.Seq[*ptrTrieRangePath[V]] {
 		start, stop, ok := bounds.childBounds(path.key)
 		if !ok {
@@ -174,8 +174,8 @@ func ptrTrieForwardAdj[V any](bounds Bounds) adjFunction[*ptrTrieRangePath[V]] {
 	}
 }
 
-// Sometimes a child is not within the bounds, but one of its descendants is.
 func ptrTrieReverseAdj[V any](bounds Bounds) adjFunction[*ptrTrieRangePath[V]] {
+	// Sometimes a child is not within the bounds, but one of its descendants is.
 	return func(path *ptrTrieRangePath[V]) iter.Seq[*ptrTrieRangePath[V]] {
 		start, stop, ok := bounds.childBounds(path.key)
 		if !ok {

--- a/pointertrie.go
+++ b/pointertrie.go
@@ -7,26 +7,41 @@ import (
 	"strings"
 )
 
-// A simple implementation, all pointers.
-
-// sub-packages?, because it's helpful to reuse type names like "node".
-// maybe later, at the second implementation.
-
-// NewPointerTrie returns a new, absurdly simple, and badly coded BTrie.
-// This is purely for fleshing out the unit tests, benchmarks, and fuzz tests.
-func NewPointerTrie[V any]() BTrie[V] {
-	var zero V
-	return &node[V]{zero, nil, 0, false}
-}
-
-type node[V any] struct {
+type ptrTrieNode[V any] struct {
 	value      V // valid only if isTerminal is true
-	children   []*node[V]
+	children   []*ptrTrieNode[V]
 	keyByte    byte
 	isTerminal bool
 }
 
-func (n *node[V]) Put(key []byte, value V) (V, bool) {
+// NewPointerTrie returns a new, absurdly simple, and badly coded BTrie.
+// Pointers to children are stored densely in slices.
+// This is purely for fleshing out the unit tests, benchmarks, and fuzz tests.
+func NewPointerTrie[V any]() BTrie[V] {
+	var zero V
+	return &ptrTrieNode[V]{zero, nil, 0, false}
+}
+
+func (n *ptrTrieNode[V]) Get(key []byte) (V, bool) {
+	if key == nil {
+		panic("key must be non-nil")
+	}
+	var zero V
+	for _, keyByte := range key {
+		index, found := n.search(keyByte)
+		if !found {
+			return zero, false
+		}
+		n = n.children[index]
+	}
+	// n = found key
+	if n.isTerminal {
+		return n.value, true
+	}
+	return zero, false
+}
+
+func (n *ptrTrieNode[V]) Put(key []byte, value V) (V, bool) {
 	if key == nil {
 		panic("key must be non-nil")
 	}
@@ -35,9 +50,9 @@ func (n *node[V]) Put(key []byte, value V) (V, bool) {
 		index, found := n.search(keyByte)
 		if !found {
 			k := len(key) - 1
-			child := &node[V]{value, nil, key[k], true}
+			child := &ptrTrieNode[V]{value, nil, key[k], true}
 			for k--; k >= i; k-- {
-				child = &node[V]{zero, []*node[V]{child}, key[k], false}
+				child = &ptrTrieNode[V]{zero, []*ptrTrieNode[V]{child}, key[k], false}
 			}
 			n.children = append(n.children, child)
 			copy(n.children[index+1:], n.children[index:])
@@ -57,26 +72,7 @@ func (n *node[V]) Put(key []byte, value V) (V, bool) {
 	return zero, false
 }
 
-func (n *node[V]) Get(key []byte) (V, bool) {
-	if key == nil {
-		panic("key must be non-nil")
-	}
-	var zero V
-	for _, keyByte := range key {
-		index, found := n.search(keyByte)
-		if !found {
-			return zero, false
-		}
-		n = n.children[index]
-	}
-	// n = found key
-	if n.isTerminal {
-		return n.value, true
-	}
-	return zero, false
-}
-
-func (n *node[V]) Delete(key []byte) (V, bool) {
+func (n *ptrTrieNode[V]) Delete(key []byte) (V, bool) {
 	if key == nil {
 		panic("key must be non-nil")
 	}
@@ -120,22 +116,22 @@ func (n *node[V]) Delete(key []byte) (V, bool) {
 }
 
 // An iter.Seq of these is returned from the adjFunction used internally by Range.
-// key = {node.keyByte on path from root to node}
-// It is cached here for efficiency, otherwise an iter.Seq of []*node[V] would be used directly.
+// key = path from root to node
+// It is cached here for efficiency, otherwise an iter.Seq of []*ptrTrieNode[V] would be used directly.
 // Note that the key must be cloned when yielded from Range.
-type rangePath[V any] struct {
-	node *node[V]
+type ptrTrieRangePath[V any] struct {
+	node *ptrTrieNode[V]
 	key  []byte
 }
 
-func (n *node[V]) Range(bounds Bounds) iter.Seq2[[]byte, V] {
+func (n *ptrTrieNode[V]) Range(bounds Bounds) iter.Seq2[[]byte, V] {
 	bounds = bounds.Clone()
-	root := rangePath[V]{n, []byte{}}
-	var pathItr iter.Seq[*rangePath[V]]
+	root := ptrTrieRangePath[V]{n, []byte{}}
+	var pathItr iter.Seq[*ptrTrieRangePath[V]]
 	if bounds.IsReverse() {
-		pathItr = postOrder(&root, reverseChildAdj[V](bounds))
+		pathItr = postOrder(&root, ptrTrieReverseAdj[V](bounds))
 	} else {
-		pathItr = preOrder(&root, forwardChildAdj[V](bounds))
+		pathItr = preOrder(&root, ptrTrieForwardAdj[V](bounds))
 	}
 	return func(yield func([]byte, V) bool) {
 		for path := range pathItr {
@@ -154,14 +150,14 @@ func (n *node[V]) Range(bounds Bounds) iter.Seq2[[]byte, V] {
 }
 
 // Sometimes a child is not within the bounds, but one of its descendants is.
-func forwardChildAdj[V any](bounds Bounds) adjFunction[*rangePath[V]] {
-	return func(path *rangePath[V]) iter.Seq[*rangePath[V]] {
+func ptrTrieForwardAdj[V any](bounds Bounds) adjFunction[*ptrTrieRangePath[V]] {
+	return func(path *ptrTrieRangePath[V]) iter.Seq[*ptrTrieRangePath[V]] {
 		start, stop, ok := bounds.childBounds(path.key)
 		if !ok {
 			// Unreachable because of how the trie is traversed forward.
 			panic("unreachable")
 		}
-		return func(yield func(*rangePath[V]) bool) {
+		return func(yield func(*ptrTrieRangePath[V]) bool) {
 			for _, child := range path.node.children {
 				keyByte := child.keyByte
 				if keyByte < start {
@@ -170,7 +166,7 @@ func forwardChildAdj[V any](bounds Bounds) adjFunction[*rangePath[V]] {
 				if keyByte > stop {
 					return
 				}
-				if !yield(&rangePath[V]{child, append(path.key, keyByte)}) {
+				if !yield(&ptrTrieRangePath[V]{child, append(path.key, keyByte)}) {
 					return
 				}
 			}
@@ -179,13 +175,13 @@ func forwardChildAdj[V any](bounds Bounds) adjFunction[*rangePath[V]] {
 }
 
 // Sometimes a child is not within the bounds, but one of its descendants is.
-func reverseChildAdj[V any](bounds Bounds) adjFunction[*rangePath[V]] {
-	return func(path *rangePath[V]) iter.Seq[*rangePath[V]] {
+func ptrTrieReverseAdj[V any](bounds Bounds) adjFunction[*ptrTrieRangePath[V]] {
+	return func(path *ptrTrieRangePath[V]) iter.Seq[*ptrTrieRangePath[V]] {
 		start, stop, ok := bounds.childBounds(path.key)
 		if !ok {
 			return emptySeq
 		}
-		return func(yield func(*rangePath[V]) bool) {
+		return func(yield func(*ptrTrieRangePath[V]) bool) {
 			for i := len(path.node.children) - 1; i >= 0; i-- {
 				child := path.node.children[i]
 				keyByte := child.keyByte
@@ -195,7 +191,7 @@ func reverseChildAdj[V any](bounds Bounds) adjFunction[*rangePath[V]] {
 				if keyByte < stop {
 					return
 				}
-				if !yield(&rangePath[V]{child, append(path.key, keyByte)}) {
+				if !yield(&ptrTrieRangePath[V]{child, append(path.key, keyByte)}) {
 					return
 				}
 			}
@@ -203,14 +199,14 @@ func reverseChildAdj[V any](bounds Bounds) adjFunction[*rangePath[V]] {
 	}
 }
 
-func (n *node[V]) String() string {
+func (n *ptrTrieNode[V]) String() string {
 	var s strings.Builder
 	n.printNode(&s, "")
 	return s.String()
 }
 
 //nolint:revive
-func (n *node[V]) printNode(s *strings.Builder, indent string) {
+func (n *ptrTrieNode[V]) printNode(s *strings.Builder, indent string) {
 	if indent == "" {
 		s.WriteString("[]")
 	} else {
@@ -226,7 +222,7 @@ func (n *node[V]) printNode(s *strings.Builder, indent string) {
 	}
 }
 
-func (n *node[V]) search(byt byte) (int, bool) {
+func (n *ptrTrieNode[V]) search(byt byte) (int, bool) {
 	// This is weirdly slightly faster than sort.Search.
 	for i := range len(n.children) {
 		keyByte := n.children[i].keyByte


### PR DESCRIPTION
This is faster that the pointer trie in some ways, slower in others. But it definitely takes up much more space.

- **Rename identifiers specific to the pointer-trie implementation.**
- **Add array trie implementation.**
- **Increase default fuzz time to 30 sec.**
- **Don't need number of children, just 0, 1, or 2+.**
- **Make an array trie node's children a pointer to an array.**
