### PR TITLE
Rename Bounds.Compare to CompareKey.

### DIFF
--- a/arraytrie.go
+++ b/arraytrie.go
@@ -126,7 +126,7 @@ func (n *arrayTrieNode[V]) Range(bounds *Bounds) iter.Seq2[[]byte, V] {
 	}
 	return func(yield func([]byte, V) bool) {
 		for path := range pathItr {
-			cmp := bounds.Compare(path.key)
+			cmp := bounds.CompareKey(path.key)
 			if cmp < 0 {
 				continue
 			}

--- a/bounds.go
+++ b/bounds.go
@@ -64,10 +64,10 @@ func (b *Bounds) DownTo(end []byte) *Bounds {
 	return &Bounds{b.Begin, end, true}
 }
 
-// Compare returns 0 if key is within this Bounds, -1 if beyond Begin, and +1 if beyond End.
-// Compare will panic if key is nil.
+// CompareKey returns 0 if key is within this Bounds, -1 if beyond Begin, and +1 if beyond End.
+// CompareKey will panic if key is nil.
 // -Inf < {} < {0}.
-func (b *Bounds) Compare(key []byte) int {
+func (b *Bounds) CompareKey(key []byte) int {
 	if key == nil {
 		panic("key cannot be nil")
 	}

--- a/bounds.go
+++ b/bounds.go
@@ -20,11 +20,11 @@ type Bounds struct {
 	// Begin is the [From] argument used to construct this Bounds.
 	Begin []byte
 
-	// End is the [BoundsBuilder.To] or [BoundsBuilder.DownTo] argument used to construct this Bounds.
+	// End is the [Bounds.To] or [Bounds.DownTo] argument used to construct this Bounds.
 	End []byte
 
-	// IsReverse is false if this Bounds was created by [BoundsBuilder.To],
-	// and true if it was created by [BoundsBuilder.DownTo].
+	// IsReverse is false if this Bounds was created by [Bounds.To],
+	// and true if it was created by [Bounds.DownTo].
 	IsReverse bool
 }
 

--- a/bounds_test.go
+++ b/bounds_test.go
@@ -130,18 +130,18 @@ func TestBoundsBuilder(t *testing.T) {
 	}
 }
 
-func TestBoundsComparePanics(t *testing.T) {
+func TestBoundsCompareKeyPanics(t *testing.T) {
 	t.Parallel()
 	assert.Panics(t, func() {
-		forwardAll.Compare(nil)
+		forwardAll.CompareKey(nil)
 	})
 	assert.Panics(t, func() {
-		reverseAll.Compare(nil)
+		reverseAll.CompareKey(nil)
 	})
 }
 
 //nolint:funlen,maintidx
-func TestBoundsCompare(t *testing.T) {
+func TestBoundsCompareKey(t *testing.T) {
 	t.Parallel()
 	for _, tt := range []struct {
 		bounds                *Bounds
@@ -263,15 +263,15 @@ func TestBoundsCompare(t *testing.T) {
 			t.Parallel()
 			count := 0
 			for _, key := range tt.before {
-				assert.Equal(t, -1, tt.bounds.Compare(key), "%s", keyName(key))
+				assert.Equal(t, -1, tt.bounds.CompareKey(key), "%s", keyName(key))
 				count++
 			}
 			for _, key := range tt.within {
-				assert.Equal(t, 0, tt.bounds.Compare(key), "%s", keyName(key))
+				assert.Equal(t, 0, tt.bounds.CompareKey(key), "%s", keyName(key))
 				count++
 			}
 			for _, key := range tt.after {
-				assert.Equal(t, +1, tt.bounds.Compare(key), "%s", keyName(key))
+				assert.Equal(t, +1, tt.bounds.CompareKey(key), "%s", keyName(key))
 				count++
 			}
 		})

--- a/pointertrie.go
+++ b/pointertrie.go
@@ -128,7 +128,7 @@ func (n *ptrTrieNode[V]) Range(bounds *Bounds) iter.Seq2[[]byte, V] {
 	}
 	return func(yield func([]byte, V) bool) {
 		for path := range pathItr {
-			cmp := bounds.Compare(path.key)
+			cmp := bounds.CompareKey(path.key)
 			if cmp < 0 {
 				continue
 			}

--- a/reference_test.go
+++ b/reference_test.go
@@ -68,7 +68,7 @@ func (r *reference) Range(bounds *Bounds) iter.Seq2[[]byte, byte] {
 	entries := []entry{}
 	for k, v := range r.m {
 		key := []byte(k)
-		if bounds.Compare(key) != 0 {
+		if bounds.CompareKey(key) != 0 {
 			continue
 		}
 		entries = append(entries, entry{key, v})


### PR DESCRIPTION
The name "Compare" implies implementing cmp.Compare[Bounds],
which is not what this function does.

- **Rename bounds.Compare to CompareKey.**
- **Fix doc comment links, BoundsBuilder was removed a while ago.**
