### PR TITLE
Upgrade to Go 1.24

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go: ['1.23']
+        go: ['1.24']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -22,4 +22,4 @@ jobs:
           go-version: ${{ matrix.go }}
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61.0
+          version: v1.64.8

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go: ['1.23']
+        go: ['1.24']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,9 +1,5 @@
 # output configuration options
 output:
-  # Make issues output unique by line.
-  # Default: true
-  uniq-by-line: false
-
   # Show statistics per linter.
   # Default: false
   show-stats: true
@@ -47,6 +43,10 @@ issues:
   # Default: 3
   max-same-issues: 0
 
+  # Make issues output unique by line.
+  # Default: true
+  uniq-by-line: false
+
   # cmdline option: -n, --new
   #
   # Show only new issues: if there are unstaged changes or untracked files,
@@ -83,11 +83,7 @@ linters:
   # Disable specific linter
   # https://golangci-lint.run/usage/linters/#disabled-by-default
   disable:
-    # causes problems if golangci-lint is compiled with a different version of go
-    - typecheck
     # not needed/wanted in this project
-    - exportloopref     # not needed with Go 1.22+
-    - execinquery       # SQL not used
     - exhaustruct       # zero values should be reasonable and useful
     - ginkgolinter      # not using this testing framework
     - gochecknoglobals  # no config options to limit to exported elements
@@ -105,7 +101,6 @@ linters:
     - wsl               # might be able to configure this well, but it'll take effort
     # replaced or duplicated
     - gocyclo           # by cyclop
-    - gomnd             # by mnd
 
 # Settings for specific linters.
 #
@@ -281,6 +276,14 @@ linters-settings:
     # Default: false
     enable-all: true
 
+  iface:
+    # List of analyzers.
+    # Default: ["identical"]
+    enable:
+      - identical # Identifies interfaces in the same package that have identical method sets.
+      - unused # Identifies interfaces that are not used anywhere in the same package where the interface is defined.
+      - opaque # Identifies functions that return interfaces, but the actual returned value is always a single concrete implementation.
+
   importas:
     # Do not allow non-required aliases.
     # Default: false
@@ -408,20 +411,10 @@ linters-settings:
           - "fmt.Printf"
           - "fmt.Println"
 
-  tenv:
-    # The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.
-    # Otherwise, only methods that take `*testing.T`, `*testing.B`, and `testing.TB` as arguments are checked.
-    # Default: false
-    all: true
-
   testifylint:
     # Enable all checkers (https://github.com/Antonboom/testifylint#checkers).
     # Default: false
     enable-all: true
-
-    disable:
-      - float-compare
-      - require-error
 
   testpackage:
     # List of packages that don't end with _test that tests are allowed to be in.
@@ -438,6 +431,11 @@ linters-settings:
     # Suggest the use of constant.Kind.String().
     # Default: false
     constant-kind: true
+
+  usetesting:
+    # Enable/disable `os.TempDir()` detections.
+    # Default: false
+    os-temp-dir: true
 
   unconvert:
     # Remove conversions that force intermediate rounding.

--- a/arraytrie.go
+++ b/arraytrie.go
@@ -15,6 +15,8 @@ type arrayTrieNode[V any] struct {
 }
 
 // NewArrayTrie returns a new BTrie with pointers to children stored in arrays.
+//
+//nolint:iface
 func NewArrayTrie[V any]() BTrie[V] {
 	return &arrayTrieNode[V]{}
 }
@@ -205,7 +207,6 @@ func (n *arrayTrieNode[V]) String() string {
 	return s.String()
 }
 
-//nolint:revive
 func (n *arrayTrieNode[V]) printNode(s *strings.Builder, keyByte byte, indent string) {
 	if indent == "" {
 		s.WriteString("[]")

--- a/bench_test.go
+++ b/bench_test.go
@@ -298,8 +298,8 @@ func createAbsent(entries map[string]byte, maxKeyLen int, random *rand.Rand) []k
 	return absent
 }
 
-func createBounds(keys keySet) ([]Bounds, []Bounds) {
-	var forward, reverse []Bounds
+//nolint:nonamedreturns
+func createBounds(keys keySet) (forward, reverse []Bounds) {
 	for i := range genMaxSize {
 		begin := keys[(2*i)%len(keys)]
 		end := keys[(2*i+1)%len(keys)]
@@ -317,8 +317,8 @@ func createBounds(keys keySet) ([]Bounds, []Bounds) {
 	return forward, reverse
 }
 
-func createFixedBounds(step int, random *rand.Rand) ([]Bounds, []Bounds) {
-	var forward, reverse []Bounds
+//nolint:nonamedreturns
+func createFixedBounds(step int, random *rand.Rand) (forward, reverse []Bounds) {
 	for low := step / 2; low < 1<<24-step; low += step {
 		high := low + step
 		keyBytes := binary.BigEndian.AppendUint32(nil, uint32(low))

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/phiryll/btrie
 
-go 1.23
+go 1.24
 
 require github.com/stretchr/testify v1.9.0
 

--- a/pointertrie.go
+++ b/pointertrie.go
@@ -18,6 +18,8 @@ type ptrTrieNode[V any] struct {
 // NewPointerTrie returns a new, absurdly simple, and badly coded BTrie.
 // Pointers to children are stored densely in slices.
 // This is purely for fleshing out the unit tests, benchmarks, and fuzz tests.
+//
+//nolint:iface
 func NewPointerTrie[V any]() BTrie[V] {
 	return &ptrTrieNode[V]{}
 }
@@ -204,7 +206,6 @@ func (n *ptrTrieNode[V]) String() string {
 	return s.String()
 }
 
-//nolint:revive
 func (n *ptrTrieNode[V]) printNode(s *strings.Builder, indent string) {
 	if indent == "" {
 		s.WriteString("[]")

--- a/reference_test.go
+++ b/reference_test.go
@@ -51,7 +51,6 @@ func (r reference) Delete(key []byte) (byte, bool) {
 	return value, ok
 }
 
-//nolint:revive
 func (r reference) String() string {
 	var s strings.Builder
 	s.WriteString("{")

--- a/reference_test.go
+++ b/reference_test.go
@@ -9,52 +9,50 @@ import (
 )
 
 func newReference() TestBTrie {
-	return &reference{map[string]byte{}}
+	return reference{}
 }
 
 // reference implements the TestBTrie interface, but it is not a trie.
 // This serves as an expected value to compare against a BTrie[byte] implementation while testing.
-type reference struct {
-	m map[string]byte
+type reference map[string]byte
+
+func (r reference) Clone() TestBTrie {
+	return maps.Clone(r)
 }
 
-func (r *reference) Clone() TestBTrie {
-	return &reference{maps.Clone(r.m)}
-}
-
-func (r *reference) Put(key []byte, value byte) (byte, bool) {
+func (r reference) Put(key []byte, value byte) (byte, bool) {
 	if key == nil {
 		panic("key must be non-nil")
 	}
 	index := string(key)
-	prev, ok := r.m[index]
-	r.m[index] = value
+	prev, ok := r[index]
+	r[index] = value
 	if ok {
 		return prev, true
 	}
 	return 0, false
 }
 
-func (r *reference) Get(key []byte) (byte, bool) {
+func (r reference) Get(key []byte) (byte, bool) {
 	if key == nil {
 		panic("key must be non-nil")
 	}
-	value, ok := r.m[string(key)]
+	value, ok := r[string(key)]
 	return value, ok
 }
 
-func (r *reference) Delete(key []byte) (byte, bool) {
+func (r reference) Delete(key []byte) (byte, bool) {
 	if key == nil {
 		panic("key must be non-nil")
 	}
 	index := string(key)
-	value, ok := r.m[index]
-	delete(r.m, index)
+	value, ok := r[index]
+	delete(r, index)
 	return value, ok
 }
 
 //nolint:revive
-func (r *reference) String() string {
+func (r reference) String() string {
 	var s strings.Builder
 	s.WriteString("{")
 	for k, v := range r.Range(forwardAll) {
@@ -64,14 +62,13 @@ func (r *reference) String() string {
 	return s.String()
 }
 
-func (r *reference) Range(bounds *Bounds) iter.Seq2[[]byte, byte] {
+func (r reference) Range(bounds *Bounds) iter.Seq2[[]byte, byte] {
 	entries := []entry{}
-	for k, v := range r.m {
+	for k, v := range r {
 		key := []byte(k)
-		if bounds.CompareKey(key) != 0 {
-			continue
+		if bounds.CompareKey(key) == 0 {
+			entries = append(entries, entry{key, v})
 		}
-		entries = append(entries, entry{key, v})
 	}
 	if bounds.IsReverse {
 		slices.SortFunc(entries, cmpEntryReverse)


### PR DESCRIPTION
- **Reference type should be a map, not a struct containing a map.**
- **Upgrade go to 1.24 and golangci-lint to 1.64.8.**
