### PR TITLE
Refactor String()

### DIFF
--- a/arraytrie.go
+++ b/arraytrie.go
@@ -203,27 +203,17 @@ func arrayTrieReverseAdj[V any](bounds *Bounds) adjFunction[*arrayTrieRangePath[
 
 func (n *arrayTrieNode[V]) String() string {
 	var s strings.Builder
-	n.printNode(&s, 0, "")
-	return s.String()
-}
-
-func (n *arrayTrieNode[V]) printNode(s *strings.Builder, keyByte byte, indent string) {
-	if indent == "" {
-		s.WriteString("[]")
-	} else {
-		fmt.Fprintf(s, "%s%02X", indent, keyByte)
-	}
+	s.WriteString("{")
 	if n.isTerminal {
-		fmt.Fprintf(s, ": %v\n", n.value)
-	} else {
-		s.WriteString("\n")
+		fmt.Fprintf(&s, ":%v, ", n.value)
 	}
-	if n.children == nil {
-		return
-	}
-	for i, child := range n.children {
-		if child != nil {
-			child.printNode(s, byte(i), indent+"  ")
+	if n.children != nil {
+		for i, child := range n.children {
+			if child != nil {
+				fmt.Fprintf(&s, "%02X:%s, ", byte(i), child)
+			}
 		}
 	}
+	s.WriteString("}")
+	return s.String()
 }

--- a/bench_test.go
+++ b/bench_test.go
@@ -195,7 +195,7 @@ func BenchmarkChildBounds(b *testing.B) {
 			forward := tt.bounds
 			reverse := From(tt.bounds.End).DownTo(tt.bounds.Begin)
 			for _, key := range tt.keys {
-				b.Run("key="+keyName(key), func(b *testing.B) {
+				b.Run("key="+btrie.KeyName(key), func(b *testing.B) {
 					b.Run("dir=forward", func(b *testing.B) {
 						b.ResetTimer()
 						for range b.N {

--- a/bounds.go
+++ b/bounds.go
@@ -69,7 +69,7 @@ func (b *Bounds) DownTo(end []byte) *Bounds {
 // -Inf < {} < {0}.
 func (b *Bounds) CompareKey(key []byte) int {
 	if key == nil {
-		panic("key cannot be nil")
+		panic("key must be non-nil")
 	}
 	if b.IsReverse {
 		if b.Begin != nil && bytes.Compare(key, b.Begin) > 0 {

--- a/bounds.go
+++ b/bounds.go
@@ -35,9 +35,9 @@ func (b *Bounds) Clone() *Bounds {
 
 func (b *Bounds) String() string {
 	if b.IsReverse {
-		return fmt.Sprintf("[%s down to %s]", keyName(b.Begin), keyName(b.End))
+		return fmt.Sprintf("[%s down to %s]", KeyName(b.Begin), KeyName(b.End))
 	}
-	return fmt.Sprintf("[%s to %s]", keyName(b.Begin), keyName(b.End))
+	return fmt.Sprintf("[%s to %s]", KeyName(b.Begin), KeyName(b.End))
 }
 
 // From returns a Bounds with the given Begin, nil End, and IsReverse false.

--- a/bounds_test.go
+++ b/bounds_test.go
@@ -28,7 +28,7 @@ var (
 
 func next(key []byte) []byte {
 	if key == nil {
-		panic("key cannot be nil")
+		panic("key must be non-nil")
 	}
 	return append(append([]byte{}, key...), 0x00)
 }

--- a/bounds_test.go
+++ b/bounds_test.go
@@ -115,7 +115,7 @@ func TestBoundsBuilder(t *testing.T) {
 		{low, nil},
 		{nil, nil},
 	} {
-		t.Run(fmt.Sprintf("(%s,%s)", keyName(tt.first), keyName(tt.second)), func(t *testing.T) {
+		t.Run(fmt.Sprintf("(%s,%s)", btrie.KeyName(tt.first), btrie.KeyName(tt.second)), func(t *testing.T) {
 			t.Parallel()
 			bounds := From(tt.first).To(tt.second)
 			assert.Equal(t, tt.first, bounds.Begin)
@@ -263,15 +263,15 @@ func TestBoundsCompareKey(t *testing.T) {
 			t.Parallel()
 			count := 0
 			for _, key := range tt.before {
-				assert.Equal(t, -1, tt.bounds.CompareKey(key), "%s", keyName(key))
+				assert.Equal(t, -1, tt.bounds.CompareKey(key), "%s", btrie.KeyName(key))
 				count++
 			}
 			for _, key := range tt.within {
-				assert.Equal(t, 0, tt.bounds.CompareKey(key), "%s", keyName(key))
+				assert.Equal(t, 0, tt.bounds.CompareKey(key), "%s", btrie.KeyName(key))
 				count++
 			}
 			for _, key := range tt.after {
-				assert.Equal(t, +1, tt.bounds.CompareKey(key), "%s", keyName(key))
+				assert.Equal(t, +1, tt.bounds.CompareKey(key), "%s", btrie.KeyName(key))
 				count++
 			}
 		})
@@ -573,9 +573,9 @@ func TestChildBounds(t *testing.T) {
 			t.Parallel()
 			for _, exp := range tt.expected {
 				start, stop, ok := btrie.TestingChildBounds(tt.bounds, exp.key)
-				assert.Equal(t, exp.start, start, "%s", keyName(exp.key))
-				assert.Equal(t, exp.stop, stop, "%s", keyName(exp.key))
-				assert.Equal(t, exp.ok, ok, "%s", keyName(exp.key))
+				assert.Equal(t, exp.start, start, "%s", btrie.KeyName(exp.key))
+				assert.Equal(t, exp.stop, stop, "%s", btrie.KeyName(exp.key))
+				assert.Equal(t, exp.ok, ok, "%s", btrie.KeyName(exp.key))
 			}
 		})
 	}

--- a/btrie.go
+++ b/btrie.go
@@ -12,6 +12,8 @@ import (
 // Implementations must clearly document if any methods accept or return references to its internal storage.
 // Implementations must clearly document if the iterator returned by Range is single-use.
 // Although nothing in this interface mandates it, all BTrie implementations in this package are tries.
+// If an implemention implements [fmt.Stringer], it should produce a value appropriate for debugging,
+// how verbose is up to the implementer.
 type BTrie[V any] interface {
 	// Get returns the value for key and whether or not it exists.
 	Get(key []byte) (value V, ok bool)
@@ -31,9 +33,9 @@ type BTrie[V any] interface {
 	Range(bounds *Bounds) iter.Seq2[[]byte, V]
 }
 
-func emptySeq[V any](_ func(V) bool) {}
-
-func keyName(key []byte) string {
+// KeyName returns a user-friendly string for key,
+// one of "nil", "empty", or the key bytes as a hex string.
+func KeyName(key []byte) string {
 	if key == nil {
 		return "nil"
 	}
@@ -42,3 +44,5 @@ func keyName(key []byte) string {
 	}
 	return fmt.Sprintf("%X", key)
 }
+
+func emptySeq[V any](_ func(V) bool) {}

--- a/btrie_test.go
+++ b/btrie_test.go
@@ -84,8 +84,6 @@ var (
 	forwardAll = From(nil).To(nil)
 	reverseAll = From(nil).DownTo(nil)
 
-	keyName = btrie.TestingKeyName
-
 	// Keys used to build test tries.
 	// These are in lexicographical order.
 	testPresentKeys = keySet{
@@ -455,7 +453,7 @@ func TestTrie(t *testing.T) {
 			trie := test.def.factory()
 			existing := map[string]byte{}
 			for key, value := range test.config.entries {
-				t.Run("op=put/key="+keyName([]byte(key)), func(t *testing.T) {
+				t.Run("op=put/key="+btrie.KeyName([]byte(key)), func(t *testing.T) {
 					assertAbsent(t, []byte(key), trie)
 					assertSame(t, existing, trie)
 
@@ -469,7 +467,7 @@ func TestTrie(t *testing.T) {
 
 			for _, keys := range test.config.absent {
 				for _, key := range keys {
-					t.Run("op=absent/key="+keyName(key), func(t *testing.T) {
+					t.Run("op=absent/key="+btrie.KeyName(key), func(t *testing.T) {
 						assertAbsent(t, key, trie)
 					})
 				}

--- a/export_test.go
+++ b/export_test.go
@@ -5,7 +5,6 @@ package btrie
 // preventing their inclusion in the public API.
 
 var (
-	TestingKeyName        = keyName
 	TestingChildBounds    = (*Bounds).childBounds
 	TestingPreOrder       = preOrder[int]
 	TestingPostOrder      = postOrder[int]

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -6,6 +6,7 @@ import (
 	rand "math/rand/v2"
 	"testing"
 
+	"github.com/phiryll/btrie"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -87,8 +88,8 @@ func FuzzGet(f *testing.F) {
 		expected, expectedOk := ref.Get(key)
 		for _, fuzz := range fuzzTries {
 			actual, actualOk := fuzz.trie.Get(key)
-			assert.Equal(t, expectedOk, actualOk, "%s: %s", fuzz.def.name, keyName(key))
-			assert.Equal(t, expected, actual, "%s: %s", fuzz.def.name, keyName(key))
+			assert.Equal(t, expectedOk, actualOk, "%s: %s", fuzz.def.name, btrie.KeyName(key))
+			assert.Equal(t, expected, actual, "%s: %s", fuzz.def.name, btrie.KeyName(key))
 		}
 	})
 }
@@ -101,11 +102,11 @@ func FuzzPut(f *testing.F) {
 		expected, expectedOk := ref.Put(key, value)
 		for _, fuzz := range fuzzTries {
 			actual, actualOk := fuzz.trie.Put(key, value)
-			assert.Equal(t, expectedOk, actualOk, "%s: %s=%d", fuzz.def.name, keyName(key), value)
-			assert.Equal(t, expected, actual, "%s: %s=%d", fuzz.def.name, keyName(key), value)
+			assert.Equal(t, expectedOk, actualOk, "%s: %s=%d", fuzz.def.name, btrie.KeyName(key), value)
+			assert.Equal(t, expected, actual, "%s: %s=%d", fuzz.def.name, btrie.KeyName(key), value)
 			actual, ok := fuzz.trie.Get(key)
-			assert.True(t, ok, "%s: %s=%d", fuzz.def.name, keyName(key), value)
-			assert.Equal(t, value, actual, "%s: %s=%d", fuzz.def.name, keyName(key), value)
+			assert.True(t, ok, "%s: %s=%d", fuzz.def.name, btrie.KeyName(key), value)
+			assert.Equal(t, value, actual, "%s: %s=%d", fuzz.def.name, btrie.KeyName(key), value)
 		}
 	})
 }
@@ -118,11 +119,11 @@ func FuzzDelete(f *testing.F) {
 		expected, expectedOk := ref.Delete(key)
 		for _, fuzz := range fuzzTries {
 			actual, actualOk := fuzz.trie.Delete(key)
-			assert.Equal(t, expectedOk, actualOk, "%s: %s", fuzz.def.name, keyName(key))
-			assert.Equal(t, expected, actual, "%s: %s", fuzz.def.name, keyName(key))
+			assert.Equal(t, expectedOk, actualOk, "%s: %s", fuzz.def.name, btrie.KeyName(key))
+			assert.Equal(t, expected, actual, "%s: %s", fuzz.def.name, btrie.KeyName(key))
 			actual, ok := fuzz.trie.Get(key)
-			assert.False(t, ok, "%s: %s", fuzz.def.name, keyName(key))
-			assert.Equal(t, byte(0), actual, "%s: %s", fuzz.def.name, keyName(key))
+			assert.False(t, ok, "%s: %s", fuzz.def.name, btrie.KeyName(key))
+			assert.Equal(t, byte(0), actual, "%s: %s", fuzz.def.name, btrie.KeyName(key))
 		}
 	})
 }
@@ -158,22 +159,22 @@ func FuzzMixed(f *testing.F) {
 		expected, expectedOk := ref.Put(key, value)
 		for _, fuzz := range fuzzTries {
 			actual, actualOk := fuzz.trie.Put(key, value)
-			assert.Equal(t, expectedOk, actualOk, "%s: %s=%d", fuzz.def.name, keyName(key), value)
-			assert.Equal(t, expected, actual, "%s: %s=%d", fuzz.def.name, keyName(key), value)
+			assert.Equal(t, expectedOk, actualOk, "%s: %s=%d", fuzz.def.name, btrie.KeyName(key), value)
+			assert.Equal(t, expected, actual, "%s: %s=%d", fuzz.def.name, btrie.KeyName(key), value)
 			actual, ok := fuzz.trie.Get(key)
-			assert.True(t, ok, "%s: %s=%d", fuzz.def.name, keyName(key), value)
-			assert.Equal(t, value, actual, "%s: %s=%d", fuzz.def.name, keyName(key), value)
+			assert.True(t, ok, "%s: %s=%d", fuzz.def.name, btrie.KeyName(key), value)
+			assert.Equal(t, value, actual, "%s: %s=%d", fuzz.def.name, btrie.KeyName(key), value)
 		}
 
 		key = keyForFuzzInputs(fuzzDeleteKey, fuzzDeleteKeyLen)
 		expected, expectedOk = ref.Delete(key)
 		for _, fuzz := range fuzzTries {
 			actual, actualOk := fuzz.trie.Delete(key)
-			assert.Equal(t, expectedOk, actualOk, "%s: %s", fuzz.def.name, keyName(key))
-			assert.Equal(t, expected, actual, "%s: %s", fuzz.def.name, keyName(key))
+			assert.Equal(t, expectedOk, actualOk, "%s: %s", fuzz.def.name, btrie.KeyName(key))
+			assert.Equal(t, expected, actual, "%s: %s", fuzz.def.name, btrie.KeyName(key))
 			actual, ok := fuzz.trie.Get(key)
-			assert.False(t, ok, "%s: %s", fuzz.def.name, keyName(key))
-			assert.Equal(t, byte(0), actual, "%s: %s", fuzz.def.name, keyName(key))
+			assert.False(t, ok, "%s: %s", fuzz.def.name, btrie.KeyName(key))
+			assert.Equal(t, byte(0), actual, "%s: %s", fuzz.def.name, btrie.KeyName(key))
 		}
 	})
 }

--- a/pointertrie.go
+++ b/pointertrie.go
@@ -200,28 +200,6 @@ func ptrTrieReverseAdj[V any](bounds *Bounds) adjFunction[*ptrTrieRangePath[V]] 
 	}
 }
 
-func (n *ptrTrieNode[V]) String() string {
-	var s strings.Builder
-	n.printNode(&s, "")
-	return s.String()
-}
-
-func (n *ptrTrieNode[V]) printNode(s *strings.Builder, indent string) {
-	if indent == "" {
-		s.WriteString("[]")
-	} else {
-		fmt.Fprintf(s, "%s%02X", indent, n.keyByte)
-	}
-	if n.isTerminal {
-		fmt.Fprintf(s, ": %v\n", n.value)
-	} else {
-		s.WriteString("\n")
-	}
-	for _, child := range n.children {
-		child.printNode(s, indent+"  ")
-	}
-}
-
 func (n *ptrTrieNode[V]) search(byt byte) (int, bool) {
 	// Copied and tweaked from sort.Search. Inlining this is much, much faster.
 	// Invariant: child[i-1] < byt <= child[j]
@@ -241,4 +219,17 @@ func (n *ptrTrieNode[V]) search(byt byte) (int, bool) {
 		}
 	}
 	return i, false
+}
+
+func (n *ptrTrieNode[V]) String() string {
+	var s strings.Builder
+	s.WriteString("{")
+	if n.isTerminal {
+		fmt.Fprintf(&s, ":%v, ", n.value)
+	}
+	for _, child := range n.children {
+		fmt.Fprintf(&s, "%02X:%s, ", child.keyByte, child)
+	}
+	s.WriteString("}")
+	return s.String()
 }

--- a/reference_test.go
+++ b/reference_test.go
@@ -6,6 +6,8 @@ import (
 	"maps"
 	"slices"
 	"strings"
+
+	"github.com/phiryll/btrie"
 )
 
 func newReference() TestBTrie {
@@ -51,16 +53,6 @@ func (r reference) Delete(key []byte) (byte, bool) {
 	return value, ok
 }
 
-func (r reference) String() string {
-	var s strings.Builder
-	s.WriteString("{")
-	for k, v := range r.Range(forwardAll) {
-		fmt.Fprintf(&s, "%s:%v, ", keyName(k), v)
-	}
-	s.WriteString("}")
-	return s.String()
-}
-
 func (r reference) Range(bounds *Bounds) iter.Seq2[[]byte, byte] {
 	entries := []entry{}
 	for k, v := range r {
@@ -81,4 +73,14 @@ func (r reference) Range(bounds *Bounds) iter.Seq2[[]byte, byte] {
 			}
 		}
 	}
+}
+
+func (r reference) String() string {
+	var s strings.Builder
+	s.WriteString("{")
+	for k, v := range r.Range(forwardAll) {
+		fmt.Fprintf(&s, "%s:%v, ", btrie.KeyName(k), v)
+	}
+	s.WriteString("}")
+	return s.String()
 }

--- a/reference_test.go
+++ b/reference_test.go
@@ -78,8 +78,8 @@ func (r reference) Range(bounds *Bounds) iter.Seq2[[]byte, byte] {
 func (r reference) String() string {
 	var s strings.Builder
 	s.WriteString("{")
-	for k, v := range r.Range(forwardAll) {
-		fmt.Fprintf(&s, "%s:%v, ", btrie.KeyName(k), v)
+	for _, key := range slices.Sorted(maps.Keys(r)) {
+		fmt.Fprintf(&s, "%s:%v, ", btrie.KeyName([]byte(key)), r[key])
 	}
 	s.WriteString("}")
 	return s.String()


### PR DESCRIPTION
The new Sprint(BTrie) and FPrint(io.Writer, BTrie) functions work for
all BTries, provided they properly implement Range.

- **Normalize panic language, "must" instead of "cannot".**
- **Export KeyName function.**
- **Use String() for debugging, not pretty-printing.**
- **Add Sprint and Fprint pretty-printing functions.**
