### PR TITLE
improve reference range

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -636,10 +636,6 @@ func BenchmarkDelete(b *testing.B) {
 //nolint:gocognit
 func benchRange(b *testing.B, getBounds func(*testTrie) ([]Bounds, []Bounds)) {
 	for _, bench := range createTestTries(benchTrieConfigs) {
-		if _, ok := bench.trie.(*reference); ok {
-			// reference.Range() creation is grossly inefficient
-			continue
-		}
 		forward, reverse := getBounds(bench)
 		original := bench.trie
 		trie := original.Clone()

--- a/bounds.go
+++ b/bounds.go
@@ -9,13 +9,13 @@ import (
 // Bounds is the argument type for [BTrie.Range].
 // A nil value for [Bounds.Begin] or [Bounds.End] represents +/-Inf;
 // which one depends on the value of [Bounds.IsReverse].
-// Note that an empty begin/end value is not nil; -Inf < []byte{} < []byte{0}.
+// Note that an empty value is not nil; -Inf < []byte{} < []byte{0}.
 // For non-nil values, Begin is inclusive and End is exclusive regardless of the direction.
 // [Bounds.Begin] and [Bounds.End] return references to internal slices.
 // Ways to construct a Bounds instance:
 //
-//	From(begin).To(end)      // IsReverse() is false
-//	From(begin).DownTo(end)  // IsReverse() is true
+//	From(begin).To(end)      // IsReverse is false
+//	From(begin).DownTo(end)  // IsReverse is true
 type Bounds struct {
 	// Begin is the [From] argument used to construct this Bounds.
 	Begin []byte

--- a/btrie_test.go
+++ b/btrie_test.go
@@ -477,11 +477,11 @@ func TestTrie(t *testing.T) {
 				ref := createReferenceTrie(test.config)
 				for _, bounds := range test.config.forward {
 					assert.Equal(t, collect(ref.Range(&bounds)), collect(trie.Range(&bounds)),
-						"%s", bounds)
+						"%s", &bounds)
 				}
 				for _, bounds := range test.config.reverse {
 					assert.Equal(t, collect(ref.Range(&bounds)), collect(trie.Range(&bounds)),
-						"%s", bounds)
+						"%s", &bounds)
 				}
 				// need an early yield for test coverage
 				count := 0


### PR DESCRIPTION
- **Improve reference.Range implementation, much more efficient now.**
- ***Bounds has a String method, not Bounds.**
- **Minor fixes to Bounds doc comments.**
